### PR TITLE
Defined color variables for light (default) theme and apply it

### DIFF
--- a/src/components/Weather.css
+++ b/src/components/Weather.css
@@ -1,3 +1,12 @@
+:root{
+    --page-background-color: #f0f4f8;
+    --interface-background-color: #ffffff;
+    --text-n-icons-color: #1e293b;
+    --highlight-color: #3b82f6;
+    --block-shadow-color: rgba(0, 0, 0, 0.1);
+    --element-background-color: #e2e8f0;
+}
+
 .weather {
   place-self: center;
   padding: 40px;

--- a/src/components/Weather.css
+++ b/src/components/Weather.css
@@ -1,20 +1,22 @@
-:root{
-    --page-background-color: #f0f4f8;
-    --interface-background-color: #ffffff;
-    --text-n-icons-color: #1e293b;
-    --highlight-color: #3b82f6;
-    --block-shadow-color: rgba(0, 0, 0, 0.1);
-    --element-background-color: #e2e8f0;
+:root {
+  --interface-background-color: #ffffff;
+  --text-n-icons-primary-color: #1e293b;
+  --text-n-icons-secondary-color: #64748b;
+  --block-shadow-color: rgba(0, 0, 0, 0.1);
+  --element-background-color: #e2e8f0;
+  --highlight-color: #bfdbfe;
 }
 
 .weather {
   place-self: center;
   padding: 40px;
   border-radius: 10px;
-  background-image: linear-gradient(45deg, #2f4680, #500ae4);
+  background-color: var(--interface-background-color);
   display: flex;
   flex-direction: column;
   align-items: center;
+  color: var(--text-n-icons-primary-color);
+  box-shadow: 10px 10px 5px 0px var(--block-shadow-color);
 }
 
 .search-bar {
@@ -29,62 +31,73 @@
   outline: none;
   border-radius: 40px;
   padding-left: 25px;
-  color: #626262;
-  background: #ebfffc;
+  color: var(--text-n-icons-primary-color);
+  background: var(--element-background-color);
   font-size: 18px;
+  color: var(--text-n-icons-secondary-color);
 }
 
-.search-bar img{
-    width: 50px;
-    padding: 15px;
-    border-radius: 50%;
-    background: #ebfffc;
-    cursor: pointer;
+.search-bar input:hover {
+  background: var(--highlight-color);
+  transition: all 0.3s ease-in-out; /*-------------------*/
 }
 
-.weather-icon{
-    width: 150px;
-    margin: 30px 0;
+.search-bar img {
+  width: 50px;
+  padding: 15px;
+  border-radius: 50%;
+  background: var(--element-background-color);
+  cursor: pointer;
 }
 
-.temperature{
-    color: #fff;
-    font-size: 80px;
-    line-height: 1;
+.search-bar img:hover {
+    background: var(--highlight-color);
+    transition: all 0.3s ease-in-out; /*-------------------*/
 }
 
-.location{
-    color: #fff;
-    font-size: 40px;
+.weather-icon {
+  width: 150px;
+  margin: 30px 0;
 }
 
-.weather-data{
-    width: 100%;
-    margin-top: 40px;
-    color:#fff;
-    display: flex;
-    justify-content: space-between;
+.temperature {
+  color: var(--text-n-icons-primary-color);
+  font-size: 80px;
+  line-height: 1;
 }
 
-.weather-data .col{
-    display: flex;
-    align-items: flex-start;
-    gap: 12px;
-    font-size: 22px;
+.location {
+  color: var(--text-n-icons-primary-color);
+  font-size: 40px;
 }
 
-.weather-data .col span{
-    display: block;
-    font-size: 16px;
+.weather-data {
+  width: 100%;
+  margin-top: 40px;
+  color: var(--text-n-icons-primary-color);
+  display: flex;
+  justify-content: space-between;
 }
 
-.weather-data .col img{
-    width: 26px;
-    margin-top: 10px;
+.weather-data .col {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  font-size: 22px;
 }
 
-.weather-conditions{
-    width: 150px;
-    padding: 15px;
-    fill: #fff;
+.weather-data .col span {
+  display: block;
+  font-size: 16px;
+}
+
+.weather-data .col img {
+  width: 26px;
+  margin-top: 10px;
+}
+
+.weather-conditions {
+  width: 150px;
+  padding: 15px;
+  fill: var(--text-n-icons-primary-color);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,9 @@
 @import url("https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap");
 
+:root {
+  --page-background-color: #f0f4f8;
+}
+
 * {
   margin: 0;
   padding: 0;
@@ -10,5 +14,5 @@
 .app {
   min-height: 100vh;
   display: grid;
-  background: #e2d4ff;
+  background: var(--page-background-color);
 }


### PR DESCRIPTION
Defined 7 color variables and applied them throughout the project.

- 6 variables are used in the [Weather component styles](https://github.com/ivan-chukhalo/waz-up/compare/defining-css-variables?expand=1#diff-0acc912f3c774b8dcc898d164140ac8e1bdbde19090d6a1046bcaad331f42d10)
- 1 variable is used in [index.css](https://github.com/ivan-chukhalo/waz-up/compare/defining-css-variables?expand=1#diff-85da366246340e911d7a0eb9153e64137a1b31f0686c74d9aef9ae4f032cb09e)

All hardcoded color values have been replaced with the corresponding variables.

Additionally:
- Added hover styles with smooth transitions for the search icon and search input.
- Added box-shadow for the app block.

Closes #8
