### PR TITLE
fix: change alt text for wind icon

### DIFF
--- a/src/components/Weather.jsx
+++ b/src/components/Weather.jsx
@@ -73,7 +73,7 @@ const Weather = () => {
           </div>
         </div>
         <div className="col">
-          <img src={wind_icon} alt="humidity" />
+          <img src={wind_icon} alt="wind" />
           <div>
             <p>{weatherData.windSpeed} m/h</p>
             <span>Wind Speed</span>


### PR DESCRIPTION
Wind icon in 'wind speed' section had wrong alt text. It said 'humidity'. Changed to 'wind'.

Fixes #10
