### PR TITLE
fix: resolve theme switching problef when page is dark

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,7 +7,7 @@ const App = () => {
 const {theme} = useTheme()
 
   return (
-    <div className={`app ${theme}`}>
+    <div className={`app`}>
       <Weather/>
     </div>
   )

--- a/src/hooks/useTheme.jsx
+++ b/src/hooks/useTheme.jsx
@@ -7,6 +7,7 @@ export default function useTheme() {
 
   useEffect(() => {
     localStorage.setItem("theme", theme);
+    document.documentElement.classList.toggle("dark", theme === "dark");
   }, [theme]);
 
   const toggleTheme = () => {


### PR DESCRIPTION
The bug had two parts:

1. The `div.app` element was receiving the `theme` state (class), but it was not affected by the `useTheme` hook. As a result, when the page was opened and the 'theme' value in localStorage was set to `"dark"`, the element was initialized with the `dark` class but could not remove it. This caused the element to be permanently styled with the dark theme, and all its descendants inherited the dark theme CSS variables.

2. In `useTheme.js`, `document.documentElement.classList.toggle` is only called when the toggle button is clicked. However, on the initial load (e.g., when `"dark"` is saved in `localStorage`), the `dark` class is not applied automatically, so the theme does not reflect the saved state.
